### PR TITLE
曲順にデフォルトで入る数字をメソッド化

### DIFF
--- a/app/models/setlist.rb
+++ b/app/models/setlist.rb
@@ -8,4 +8,13 @@ class Setlist < ApplicationRecord
   accepts_nested_attributes_for :songs
   
   validates :title, presence: true, length: { maximum: 100 }
+
+  def new_song_number
+    max = 0
+    songs.all.each do |song| 
+      max = song.trackorder if song.trackorder > max
+    end
+    return max + 1
+  end
+
 end

--- a/app/views/setlists/edit_track.html.erb
+++ b/app/views/setlists/edit_track.html.erb
@@ -27,7 +27,7 @@
       <div class="form-inline">
         <%= form_for [@setlist, @song] do |f| %>
             <%= f.label :trackorder, '曲順' %>
-            <%= f.number_field :trackorder, value: @setlist.songs.count + 1, in: 0...201, class: 'form-control' %>
+            <%= f.number_field :trackorder, value: @setlist.new_song_number, in: 0...201, class: 'form-control' %>
             <%= f.label :title, '曲名' %>
             <%= f.text_field :title, class: 'form-control' %>
 


### PR DESCRIPTION
新しく曲を登録する際には曲順にデフォルトで「そのセットリストの曲数＋１」が入るようになっていたが、「一番大きいtrackorder＋1」が入るように変更した。