### PR TITLE
レスポンシブ対応

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -67,3 +67,8 @@ footer {
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color:#85beab;
 }
+
+img {
+	max-width: 100%;
+	height: auto;
+}

--- a/app/views/static_pages/description.html.erb
+++ b/app/views/static_pages/description.html.erb
@@ -1,10 +1,10 @@
-<div class="text-center">
-  <%= image_tag 'live.jpg' %>
+<div class="col-sm-12 text-center">
+  <img src='/assets/live.jpg' />
 </div>
 
 <br>
 
-<div class="col-lg-offset-1 col-sm-offset-0 col-lg-10 col-sm-12 text-left">
+<div class="col-lg-offset-1 col-sm-offset-0 col-sm-12 col-lg-10 text-left">
   <h4><strong>1997年に日本で初めてロック・フェスティバルが開催されてから年々フェスは増え続けています。近年ではフェスやライブに行くことがブームとなっており、自分の行ったライブのセットリストを後から確認したり、これから行くライブの予習をしたいということもあると思います。</strong></h4>
   <h4><strong>このMyFavoriteSongではユーザー同士が共有する形でセットリストを共有することができます。</strong></h4>
 
@@ -15,35 +15,35 @@
     <h4><strong><li>ログインしましょう（ログインしなくても、セットリストの閲覧・編集は行うことができます）</li></strong></h4>
     <h4><strong><li>セットリストを追加したいミュージシャンを右上の検索バーから検索してください</li></strong></h4>
     <h4>もし、ミュージシャンが登録されていなければ「+Add Musician」からミュージシャンを追加してください</h4>
-    <%= image_tag 'add_musician.png',:size => '640x288' %>
+    <img src='/assets/add_musician.png', width="640", height="288" />
     <h4><strong><li>ミュージシャンページの「+Add Setlist」からセットリストを追加してください</li></strong></h4>
   </ol>
 
   <br>
+</div>
 
-  <h2 class="text-muted"><strong>その他機能</strong></h2>
+<h2 class="text-muted"><strong>その他機能</strong></h2>
 
-  <div class="col-lg-6">
-    <div class="panel panel-success">
-      <div class="panel-heading">
-        <h3 class="panel-title"><strong>メール通知機能</strong></h3>
-      </div>
-      <div class="panel-body text-center">
-        <%= image_tag 'mail.png' ,:size =>'100x100' %>
-        <h4>ユーザーがお気に入りに登録したミュージシャンのセットリストが追加されるとメールで通知されます。</h4>
-      </div>
+<div class="col-sm-12 col-lg-6">
+  <div class="panel panel-success">
+    <div class="panel-heading">
+      <h3 class="panel-title"><strong>メール通知機能</strong></h3>
+    </div>
+    <div class="panel-body text-center">
+      <img src='/assets/mail.png', width="100", height="100" />
+      <h4>ユーザーがお気に入りに登録したミュージシャンのセットリストが追加されるとメールで通知されます。</h4>
     </div>
   </div>
+</div>
 
-  <div class="col-lg-6">
-    <div class="panel panel-primary">
-      <div class="panel-heading">
-        <h3 class="panel-title"><strong>Twitter連携機能</strong></h3>
-      </div>
-      <div class="panel-body text-center">
-        <%= image_tag 'twitter.png' ,:size =>'100x100' %>
-        <h4>ライブに関する直近1週間以内のツイートを表示します。twitterアカウントでログインすることも可能です。</h4>
-      </div>
+<div class="col-lg-6 col-sm-12">
+  <div class="panel panel-primary">
+    <div class="panel-heading">
+      <h3 class="panel-title"><strong>Twitter連携機能</strong></h3>
+    </div>
+    <div class="panel-body text-center">
+      <img src='/assets/twitter.png', width="100", height="100" />
+      <h4>ライブに関する直近1週間以内のツイートを表示します。twitterアカウントでログインすることも可能です。</h4>
     </div>
   </div>
 </div>

--- a/app/views/static_pages/description.html.erb
+++ b/app/views/static_pages/description.html.erb
@@ -19,12 +19,9 @@
     <h4><strong><li>ミュージシャンページの「+Add Setlist」からセットリストを追加してください</li></strong></h4>
   </ol>
 
-  <br>
-</div>
+  <h2 class="text-muted"><strong>その他機能</strong></h2>
 
-<h2 class="text-muted"><strong>その他機能</strong></h2>
-
-<div class="col-sm-12 col-lg-6">
+  <div class="col-sm-12 col-lg-6">
   <div class="panel panel-success">
     <div class="panel-heading">
       <h3 class="panel-title"><strong>メール通知機能</strong></h3>
@@ -36,7 +33,7 @@
   </div>
 </div>
 
-<div class="col-lg-6 col-sm-12">
+<div class="col-sm-12 col-lg-6">
   <div class="panel panel-primary">
     <div class="panel-heading">
       <h3 class="panel-title"><strong>Twitter連携機能</strong></h3>
@@ -46,4 +43,5 @@
       <h4>ライブに関する直近1週間以内のツイートを表示します。twitterアカウントでログインすることも可能です。</h4>
     </div>
   </div>
+</div>
 </div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -48,6 +48,9 @@
             <span class="fa fa-twitter"></span> Twitterでログイン
           <% end %>
 
+          <br>
+          <br>
+
           <%= link_to '/auth/facebook', class: "btn btn-social btn-facebook" do %>
             <span class="fa fa-facebook"></span> Facebookでログイン
           <% end %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION
画像のレスポンシブ対応、image_tagを使うとメディアクエリが使いにくくなるため、HTMLでシンプルに画像表示。
プリコンパイルをtrueにする必要があった。